### PR TITLE
Dont polyscript symlinks

### DIFF
--- a/7.4/buster/apache/Dockerfile
+++ b/7.4/buster/apache/Dockerfile
@@ -236,6 +236,8 @@ RUN set -eux; \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
+# enable internationalization
+		--enable-intl \
 		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear") and will be removed in PHP 8+; see also https://github.com/docker-library/php/issues/846#issuecomment-505638494
 		--with-pear \

--- a/7.4/buster/apache/Dockerfile
+++ b/7.4/buster/apache/Dockerfile
@@ -236,8 +236,6 @@ RUN set -eux; \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
-# enable internationalization
-		--enable-intl \
 		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear") and will be removed in PHP 8+; see also https://github.com/docker-library/php/issues/846#issuecomment-505638494
 		--with-pear \

--- a/polyscripting/src/transformer/tok-php-transformer.php
+++ b/polyscripting/src/transformer/tok-php-transformer.php
@@ -114,6 +114,9 @@ function get_ext($opts)
 
 function polyscriptify($file_name, $fileOut)
 {
+    // ignore symlinks
+    if (is_link($file_name)) { return; }
+
     global $is_test;
     $file_str = file_get_contents($file_name);
     $fp = fopen($fileOut, 'w');


### PR DESCRIPTION
Don't polyscriptify a file if it's a symlink. It seems the RecursiveDirectoryIterator doesn't follow symlinks unless asked to do so through a flag: https://www.php.net/manual/en/class.filesystemiterator.php#filesystemiterator.constants.follow-symlinks