### PR TITLE
Don't scramble the ) symbol which causes PHP 8 to break.

### DIFF
--- a/polyscripting/src/scrambler/dictionaryHandler.go
+++ b/polyscripting/src/scrambler/dictionaryHandler.go
@@ -106,8 +106,8 @@ var CharMatches = []string{}
 
 var CharStrRegex = regexp.MustCompile("(\")[^\\w\"]{2,}[ \"]")
 
-var symbolChars = [...]string{")", "(", "-", "~", "^", "&", "@", "!", "|", "+", ":", "=", ",", "%", "]"}
-var specialChars = []string{"(", ")", "]"}
+var symbolChars = [...]string{"(", "-", "~", "^", "&", "@", "!", "|", "+", ":", "=", ",", "%", "]"}
+var specialChars = []string{"(", "]"}
 
 func shuffle() []string {
 	r := rand.New(rand.NewSource(time.Now().Unix()))

--- a/polyscripting/src/scrambler/scrambler.go
+++ b/polyscripting/src/scrambler/scrambler.go
@@ -147,7 +147,7 @@ func substituteWordsInString(line string) string {
 		line = strings.Replace(line, strings.TrimPrefix(matchedRegex, "\""), key, 1)
 		matchedRegex = KeywordsRegex.FindString(line)
 
-		if (matchedRegex == matchedRegexStart) {
+		if matchedRegex == matchedRegexStart {
 			fmt.Println(matchedRegex + ": Not added to dictionary.")
 			return line
 		}

--- a/polyscripting/src/transformer/tok-php-transformer.php
+++ b/polyscripting/src/transformer/tok-php-transformer.php
@@ -28,7 +28,7 @@ if ($is_snip ) {
 }
 
 
-echo "Polyscript from dir " . $root_path . " to dir:" . $out, PHP_EOL;
+echo "Polyscript " . $root_path . " to " . $out, PHP_EOL;
 
 if (!is_dir($out))
 {


### PR DESCRIPTION
Don't scramble the ) symbol which causes PHP 8 to break.